### PR TITLE
Increase granularity of Importer::Base specs

### DIFF
--- a/lib/smuggle/importer/base.rb
+++ b/lib/smuggle/importer/base.rb
@@ -40,6 +40,8 @@ module Smuggle
         end
       end
 
+      private
+
       def defined_attributes
         return self.class.attributes if self.class.attributes?
 

--- a/lib/smuggle/importer/base.rb
+++ b/lib/smuggle/importer/base.rb
@@ -6,8 +6,8 @@ module Smuggle
       class << self
         attr_writer :attributes
 
-        def inherited(base)
-          base.attributes = []
+        def inherited(subclass)
+          subclass.attributes = []
         end
 
         def attributes(*names)
@@ -43,7 +43,9 @@ module Smuggle
       def defined_attributes
         return self.class.attributes if self.class.attributes?
 
-        model.attribute_names if model.respond_to?(:attribute_names)
+        return model.attribute_names if model.respond_to?(:attribute_names)
+
+        []
       end
     end
   end

--- a/spec/smuggle/importer/base_spec.rb
+++ b/spec/smuggle/importer/base_spec.rb
@@ -57,14 +57,4 @@ RSpec.describe Smuggle::Importer::Base do
       end
     end
   end
-
-  describe "#defined_attributes" do
-    subject(:defined_attributes) { importer.defined_attributes }
-
-    context "when the importer is empty" do
-      let(:importer_class) { Importers::EmptyImporter }
-
-      it { is_expected.to eq([]) }
-    end
-  end
 end

--- a/spec/smuggle/importer/base_spec.rb
+++ b/spec/smuggle/importer/base_spec.rb
@@ -3,14 +3,66 @@
 require "spec_helper"
 
 RSpec.describe Smuggle::Importer::Base do
-  describe "#to_h" do
-    let(:importer) { Importers::UserImporter.new(row, User) }
-    let(:row) do
-      CSV::Row.new(%i[first_name last_name location unnecessary_field], %w[Rick Sanchez Earth Plumbus])
+  subject(:importer) { importer_class.new(row, User) }
+
+  context "when the importer is empty" do
+    let(:importer_class) { Importers::EmptyImporter }
+    let(:row) { CSV::Row.new(%i[name location], %w[Rick Earth]) }
+
+    describe "#persist" do
+      subject(:persist) { importer.persist }
+
+      it { expect { persist }.to raise_error(NotImplementedError) }
     end
 
-    it "converts csv row into an attributes hash" do
-      expect(importer.to_h).to eq(Hash(name: "Rick Sanchez", location: "Earth"))
+    describe "#to_h" do
+      subject(:to_h) { importer.to_h }
+
+      it { is_expected.to eq({}) }
+    end
+
+    describe "#defined_attributes" do
+      subject(:defined_attributes) { importer.defined_attributes }
+
+      it { is_expected.to eq([]) }
+    end
+  end
+
+  context "when the importer is basic" do
+    let(:importer_class) { Importers::BasicUserImporter }
+    let(:row) { CSV::Row.new(%i[name location unnecessary_field], %w[Rick Earth Plumbus]) }
+
+    describe "#persist" do
+      subject(:persist) { importer.persist }
+
+      it "does not raise an exception" do
+        expect { persist }.not_to raise_error
+      end
+    end
+
+    describe "#to_h" do
+      subject(:to_h) { importer.to_h }
+
+      it "contains the requested attributes" do
+        expect(to_h).to include(name: "Rick", location: "Earth")
+      end
+
+      it "does not contain other keys" do
+        expect(to_h.keys).to contain_exactly(:name, :location)
+      end
+    end
+  end
+
+  context "when the importer combines two fields" do
+    let(:importer_class) { Importers::CombineImporter }
+    let(:row) { CSV::Row.new(%i[first_name last_name], %w[Rick Sanchez]) }
+
+    describe "#to_h" do
+      subject(:to_h) { importer.to_h }
+
+      it "contains the attribute combined from the CSV" do
+        expect(to_h).to include(name: "Rick Sanchez")
+      end
     end
   end
 end

--- a/spec/smuggle/importer/base_spec.rb
+++ b/spec/smuggle/importer/base_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Smuggle::Importer::Base do
     context "when the importer is empty" do
       let(:importer_class) { Importers::EmptyImporter }
 
-      specify { expect { persist }.to raise_error(NotImplementedError) }
+      it { expect { persist }.to raise_error(NotImplementedError) }
     end
 
     context "when the importer is basic" do
       let(:importer_class) { Importers::BasicUserImporter }
 
-      specify { expect { persist }.not_to raise_error }
+      it { expect { persist }.not_to raise_error }
     end
   end
 

--- a/spec/smuggle/services/import_spec.rb
+++ b/spec/smuggle/services/import_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe Smuggle::Services::Import do
     context "with importer option" do
       subject(:call) { described_class.call(model: model, filepath: filepath, importer: importer) }
 
-      let(:importer) { Importers::UserImporter }
+      let(:importer) { Importers::BasicUserImporter }
 
       it "imports rows from csv file" do
-        expect { call }.to change { importer.db.count }.from(0).to(3)
+        expect { call }.to change { importer.db.count }.by(3)
       end
 
       it { is_expected.to be_an Array }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,14 +5,18 @@ SimpleCov.start
 
 require "bundler/setup"
 require "smuggle"
+require "faker"
+require "pry"
+require "pry-byebug"
+
 require "support/user"
 require "support/exporters/with_attributes"
 require "support/exporters/without_attributes"
 require "support/exporters/with_attributes_and_labels"
-require "support/importers/user_importer"
-require "faker"
-require "pry"
-require "pry-byebug"
+require "support/importers/empty_importer"
+require "support/importers/base_importer"
+require "support/importers/basic_user_importer"
+require "support/importers/combine_importer"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/importers/base_importer.rb
+++ b/spec/support/importers/base_importer.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
 module Importers
-  class UserImporter < Smuggle::Importer::Base
-    attributes :name, :location
-
-    @db = []
-
+  # A base importer that sets up simple storage of imported data when inherited from.
+  class BaseImporter < Smuggle::Importer::Base
     class << self
       attr_accessor :db
-    end
 
-    def name
-      [row[:first_name], row[:last_name]].join(" ")
+      def inherited(subclass)
+        super
+        subclass.db = []
+      end
     end
 
     def persist

--- a/spec/support/importers/basic_user_importer.rb
+++ b/spec/support/importers/basic_user_importer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Importers
+  class BasicUserImporter < BaseImporter
+    attributes :name, :location
+  end
+end

--- a/spec/support/importers/combine_importer.rb
+++ b/spec/support/importers/combine_importer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Importers
+  class CombineImporter < BaseImporter
+    attributes :name
+
+    def name
+      [row[:first_name], row[:last_name]].join(" ")
+    end
+  end
+end

--- a/spec/support/importers/empty_importer.rb
+++ b/spec/support/importers/empty_importer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Importers
+  class EmptyImporter < Smuggle::Importer::Base
+  end
+end


### PR DESCRIPTION
![Add more grains](https://media.giphy.com/media/121sndoDqcLkoo/giphy.gif)

This PR splits up the single `it "converts csv row into an attributes hash"` test into several more granular tests.

It also adds a `BaseImporter` which handles storage of imported data when inherited from.