### PR TITLE
Add latest PR changes to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `Smuggle::Importer::Base#defined_attributes` has been made `private`.
+
 ## 0.4.0 - 2018-09-10
 
 ### Added


### PR DESCRIPTION
Depends on #18 

The latest PR didn't change a lot, except for that `Smuggle::Importer::Base#defined_attributes` can no longer be accessed publicly.